### PR TITLE
Dockerfile: use prod server, uv for faster build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,10 +7,12 @@ WORKDIR /app
 
 COPY . /app/
 
-RUN pip install --no-cache-dir -r requirements.txt
+RUN pip install uv
+
+RUN uv pip install --system --no-cache-dir -r requirements.txt
 
 RUN python manage.py collectstatic -v 3 --noinput
 
 EXPOSE 8000
 
-CMD ["python", "manage.py", "runserver", "0.0.0.0:8000"]
+CMD ["gunicorn", "mps.wsgi:application", "--bind", "0.0.0.0:8000"]


### PR DESCRIPTION
*performance go brrr*

## Before:
```
Successfully built be67c3708a6e
docker build .  1.02s user 0.58s system 4% cpu 38.688 total
```

## After:
```
Successfully built d56d93063ba6
docker build .  1.05s user 0.54s system 64% cpu 2.480 total
```
